### PR TITLE
Release Lukkit 2.1.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>unwrittenfun.minecraft</groupId>
     <artifactId>Lukkit</artifactId>
-    <version>2.1.1</version>
+    <version>2.1.2</version>
 
     <packaging>jar</packaging>
 

--- a/pom.xml
+++ b/pom.xml
@@ -62,8 +62,6 @@
     </build>
 
     <dependencies>
-
-
         <!--Avaje compiler-->
         <dependency>
             <groupId>org.avaje</groupId>
@@ -92,13 +90,6 @@
             <artifactId>bukkit</artifactId>
             <version>1.12.2-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
-        </dependency>
-
-        <!--LuaJ JME-->
-        <dependency>
-            <groupId>org.luaj</groupId>
-            <artifactId>luaj-jme</artifactId>
-            <version>3.0.1</version>
         </dependency>
 
         <!--LuaJ JSE-->

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <project>
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>unwrittenfun.minecraft</groupId>
+    <groupId>nz.co.jammehcow.lukkit</groupId>
     <artifactId>Lukkit</artifactId>
     <version>2.1.2</version>
 
@@ -23,7 +23,6 @@
                 <includes>
                     <include>plugin.yml</include>
                     <include>config.yml</include>
-                    <include>unwrittenfun/minecraft/lukkit/libs/</include>
                 </includes>
             </resource>
         </resources>

--- a/src/main/java/nz/co/jammehcow/lukkit/Utilities.java
+++ b/src/main/java/nz/co/jammehcow/lukkit/Utilities.java
@@ -78,4 +78,19 @@ public class Utilities {
     public static boolean classIsEvent(Class<?> c) {
         return Event.class.isAssignableFrom(c);
     }
+
+    /**
+     * Check that a given classpath is valid
+     *
+     * @param classPath the full classpath to validate
+     * @return whether the classpath is valid
+     */
+    public static boolean isClassPathValid(String classPath) {
+        try {
+            Class.forName(classPath);
+        } catch (ClassNotFoundException e) {
+            return false;
+        }
+        return true;
+    }
 }

--- a/src/main/java/nz/co/jammehcow/lukkit/environment/plugin/LukkitPlugin.java
+++ b/src/main/java/nz/co/jammehcow/lukkit/environment/plugin/LukkitPlugin.java
@@ -179,8 +179,10 @@ public class LukkitPlugin implements Plugin {
 
                         return newInstanceMethod.invoke(varargArray).checkvalue(1);
                     default:
-                        // TODO: throw LukkitPluginError and add to LuaEnv stack
-                        throw new IllegalStateException("Unexpected value: " + args.type());
+                        LukkitPluginException exception = new LukkitPluginException("Second argument of newInstance " +
+                                "must be of type table, not " + args.typename());
+                        LuaEnvironment.addError(exception);
+                        throw exception;
                 }
             }
         });

--- a/src/main/java/nz/co/jammehcow/lukkit/environment/wrappers/PluginWrapper.java
+++ b/src/main/java/nz/co/jammehcow/lukkit/environment/wrappers/PluginWrapper.java
@@ -212,13 +212,6 @@ public class PluginWrapper extends LuaTable {
             }
         });
 
-        set("getServer", new ZeroArgFunction() {
-            @Override
-            public LuaValue call() {
-                return CoerceJavaToLua.coerce(plugin.getServer());
-            }
-        });
-
         set("getPlugin", new ZeroArgFunction() {
             @Override
             public LuaValue call() {

--- a/src/main/java/nz/co/jammehcow/lukkit/environment/wrappers/UtilitiesWrapper.java
+++ b/src/main/java/nz/co/jammehcow/lukkit/environment/wrappers/UtilitiesWrapper.java
@@ -5,8 +5,10 @@ import nz.co.jammehcow.lukkit.environment.LuaEnvironment.ObjectType;
 import nz.co.jammehcow.lukkit.environment.plugin.LukkitPlugin;
 import nz.co.jammehcow.lukkit.environment.plugin.LukkitPluginException;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.scheduler.BukkitRunnable;
 import org.luaj.vm2.LuaTable;
 import org.luaj.vm2.LuaValue;
+import org.luaj.vm2.LuaFunction;
 import org.luaj.vm2.lib.OneArgFunction;
 import org.luaj.vm2.lib.TwoArgFunction;
 import org.luaj.vm2.lib.jse.CoerceJavaToLua;
@@ -123,6 +125,20 @@ public class UtilitiesWrapper extends LuaTable {
 
                 return LuaValue.NIL;
             }
+        });
+
+        set("getBukkitRunnable", new OneArgFunction() {
+            @Override
+            public LuaValue call( LuaValue function ) {
+                LuaFunction func = function.checkfunction();
+                BukkitRunnable task = new BukkitRunnable() {
+                    @Override
+                    public void run() {
+                        func.call();
+                    };
+                };
+                return CoerceJavaToLua.coerce(task);
+            };
         });
 
         set("getClass", new OneArgFunction() {

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -5,6 +5,8 @@ version: 2.1.2
 author: ArtexDevelopment
 authors: [jammehcow, AL_1, mathhulk]
 
+api-version: 1.13
+
 commands:
   lukkit:
     description: The main command for Lukkit

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,6 +1,6 @@
 name: Lukkit
 main: nz.co.jammehcow.lukkit.Main
-version: 2.1.1
+version: 2.1.2
 
 author: ArtexDevelopment
 authors: [jammehcow, AL_1, mathhulk]


### PR DESCRIPTION
Adds:
 - BukkitRunnable factory using LuaFunction objects

Fixes:
 - Coercing a Lua `number` to Java would produce an `Integer` object and not a primitive.

Changes:
 - Removed LuaJ-JME dependency
 - Version bump to 2.1.2
 - Updated pom package naming and include directories